### PR TITLE
Fix packaging errors due to modifying outside of OUT_DIR

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openvr_sys"
-version = "2.1.0"
+version = "2.1.1"
 edition = "2021"
 rust-version = "1.82.0"
 authors = [

--- a/build.rs
+++ b/build.rs
@@ -12,8 +12,19 @@ fn main() {
     let target_pointer_width = env::var("CARGO_CFG_TARGET_POINTER_WIDTH").unwrap();
 
     // Configure cmake to place build output in OUT_DIR
+    let out_dir_str = out_dir.to_string_lossy().into_owned();
     let mut config = cmake::Config::new("openvr");
-    config.out_dir(&out_dir); 
+    let config = config
+        .define("CMAKE_LIBRARY_OUTPUT_DIRECTORY", &out_dir_str)
+        .define("CMAKE_ARCHIVE_OUTPUT_DIRECTORY", &out_dir_str)
+        .define("CMAKE_RUNTIME_OUTPUT_DIRECTORY", &out_dir_str)
+        .define("CMAKE_LIBRARY_OUTPUT_DIRECTORY_DEBUG", &out_dir_str)
+        .define("CMAKE_LIBRARY_OUTPUT_DIRECTORY_RELEASE", &out_dir_str)
+        .define("CMAKE_ARCHIVE_OUTPUT_DIRECTORY_DEBUG", &out_dir_str)
+        .define("CMAKE_ARCHIVE_OUTPUT_DIRECTORY_RELEASE", &out_dir_str)
+        .define("CMAKE_RUNTIME_OUTPUT_DIRECTORY_DEBUG", &out_dir_str)
+        .define("CMAKE_RUNTIME_OUTPUT_DIRECTORY_RELEASE", &out_dir_str)
+        .out_dir(&out_dir); 
 
     if target_os == "macos" {
         config.define("BUILD_UNIVERSAL", "OFF");

--- a/build.rs
+++ b/build.rs
@@ -1,12 +1,19 @@
-extern crate bindgen;
-extern crate cmake;
-
+use bindgen;
+use cmake;
 use std::env;
+use std::path::PathBuf;
 
 fn main() {
-    let mut config = cmake::Config::new("openvr");
+    let out_dir = PathBuf::from(env::var("OUT_DIR").expect("Missing OUT_DIR env var"));
+
+    println!("cargo:rerun-if-changed=wrapper.hpp");
+
     let target_os = env::var("CARGO_CFG_TARGET_OS").unwrap();
     let target_pointer_width = env::var("CARGO_CFG_TARGET_POINTER_WIDTH").unwrap();
+
+    // Configure cmake to place build output in OUT_DIR
+    let mut config = cmake::Config::new("openvr");
+    config.out_dir(&out_dir); 
 
     if target_os == "macos" {
         config.define("BUILD_UNIVERSAL", "OFF");
@@ -16,6 +23,7 @@ fn main() {
     }
 
     let dst = config.build();
+
     println!("cargo:rustc-link-search=native={}/lib", dst.display());
 
     if target_os == "windows" && target_pointer_width == "64" {
@@ -32,12 +40,13 @@ fn main() {
         println!("cargo:rustc-link-lib=shell32");
     }
 
+    // Generate bindings and write them into OUT_DIR
     bindgen::builder()
         .header("wrapper.hpp")
         .constified_enum(".*")
         .prepend_enum_name(false)
         .generate()
         .expect("could not generate bindings")
-        .write_to_file("bindings.rs")
+        .write_to_file(out_dir.join("bindings.rs"))
         .expect("could not write bindings.rs");
 }

--- a/lib.rs
+++ b/lib.rs
@@ -1,6 +1,6 @@
 #![allow(non_camel_case_types, non_upper_case_globals, non_snake_case)]
 
-include!("bindings.rs");
+include!(concat!(env!("OUT_DIR"), "/bindings.rs"));
 
 #[cfg(target_os = "macos")]
 #[link(name = "Foundation", kind = "framework")]


### PR DESCRIPTION
Tried to package but got this:


``` 
cargo package
   Packaging openvr_sys v2.1.0 (D:\liv\rust-openvr-sys-og)
    Updating crates.io index
    Packaged 51 files, 1.9MiB (364.3KiB compressed)
   Verifying openvr_sys v2.1.0 (D:\liv\rust-openvr-sys-og)
   Compiling proc-macro2 v1.0.93
   Compiling windows_x86_64_msvc v0.52.6
   Compiling unicode-ident v1.0.16
   Compiling glob v0.3.2
   Compiling prettyplease v0.2.29
   Compiling libc v0.2.169
   Compiling memchr v2.7.4
   Compiling minimal-lexical v0.2.1
   Compiling shlex v1.3.0
   Compiling regex-syntax v0.8.5
   Compiling either v1.13.0
   Compiling bindgen v0.71.1
   Compiling log v0.4.25
   Compiling rustc-hash v2.1.0
   Compiling bitflags v2.8.0
   Compiling cc v1.2.10
   Compiling itertools v0.13.0
   Compiling clang-sys v1.8.1
   Compiling nom v7.1.3
   Compiling windows-targets v0.52.6
   Compiling libloading v0.8.6
   Compiling cmake v0.1.53
   Compiling regex-automata v0.4.9
   Compiling quote v1.0.38
   Compiling syn v2.0.96
   Compiling cexpr v0.6.0
   Compiling regex v1.11.1
   Compiling openvr_sys v2.1.0 (D:\liv\rust-openvr-sys-og\target\package\openvr_sys-2.1.0)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 14.31s
error: failed to verify package tarball

Caused by:
  Source directory was modified by build.rs during cargo publish. Build scripts should not modify anything outside of OUT_DIR.
  Added: D:\liv\rust-openvr-sys-og\target\package\openvr_sys-2.1.0\bindings.rs
        D:\liv\rust-openvr-sys-og\target\package\openvr_sys-2.1.0\openvr\bin
        D:\liv\rust-openvr-sys-og\target\package\openvr_sys-2.1.0\openvr\bin\win64
        D:\liv\rust-openvr-sys-og\target\package\openvr_sys-2.1.0\openvr\bin\win64\Debug
        D:\liv\rust-openvr-sys-og\target\package\openvr_sys-2.1.0\openvr\bin\win64\Debug\openvr_api64.lib

  To proceed despite this, pass the `--no-verify` flag.

```  

Now bindings and CMake is all generated into OUT_DIR and `cargo package succeeds`, I can publish after this is squashed into master.

