### PR TITLE
allow default-initialization of C structures from openvr_capi

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -56,6 +56,7 @@ fn main() {
         .header("wrapper.hpp")
         .constified_enum(".*")
         .prepend_enum_name(false)
+        .derive_default(true)
         .generate()
         .expect("could not generate bindings")
         .write_to_file(out_dir.join("bindings.rs"))


### PR DESCRIPTION
Working directly with the generated bindings, it is generally useful to default-initialize c structures to zero.

This PR add a configuration value to bindgen that insert this behavior as an impl of the `Default` trait to generated types.